### PR TITLE
Release 0.1.1

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -7,7 +7,7 @@ on:
       - 'main'
 jobs:
   build-test-and-publish:
-    name: Build, Tes, and Publish
+    name: Build, Test, and Publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "prettier": "@kienleholdings/prettier-config",
   "scripts": {
     "first-time-prebuild": "cd ./packages/utils && pnpm run build && cd ../run && pnpm run build && cd ../..",
-    "build": "node ./packages/run/lib/index.js build --parallel --packagesDir ../../",
-    "lint": "node ./packages/run/lib/index.js lint --parallel --packagesDir ../../",
-    "test": "node ./packages/run/lib/index.js test --parallel --packagesDir ../../",
-    "publish-ci": "node ./packages/publish/lib/index.js --packagesDir ../../"
+    "build": "node ./packages/run/lib/index.js build --parallel",
+    "lint": "node ./packages/run/lib/index.js lint --parallel",
+    "test": "node ./packages/run/lib/index.js test --parallel",
+    "publish-ci": "node ./packages/publish/lib/index.js"
   },
   "devDependencies": {
     "@kienleholdings/prettier-config": "^0.1.3",

--- a/packages/publish/CHANGELOG.md
+++ b/packages/publish/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2022-01-24
+
+### Added
+
+- Added a `README.md`
+
+### Changed
+
+- Updated `@kienleholdings/mrt-utils` to `0.1.1` in order to fix a bug where the script looked for
+packages in the directory where the script was stored rather than the directory where the script
+was launched from
+- Changed the default module folder from `./packages` to `packages` to allow for better Windows
+path resolution
+
+### Removed
+
+- N / A
+
 ## [0.1.0] - 2022-01-24
 
 ### Added

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -1,0 +1,48 @@
+# mrt-publish
+
+> Publish packages automatically if their version has changed
+
+## Installation
+
+With pnpm (recommended)
+
+```
+pnpm install @kienleholdings/mrt-publish
+```
+
+With yarn
+
+```
+yarn add @kienleholdings/mrt-publish
+```
+
+With npm
+
+```
+npm install @kienleholdings/mrt-publish
+```
+
+## Usage
+
+`mrt-publish <options>`
+
+## Example
+
+`mrt-run --npmCommand yarn --packagesDir ./other-packages --parallel`
+
+## Options
+
+### `--npmCommand <name>`
+
+By default, `mrt-run` uses `pnpm` for command execution. You may want to use `yarn` or `npm`
+instead, thus you can change what client we use to execute commands from here
+
+### `--packagesDir <directory>`
+
+By default, `mrt-run` searches for packages in `./packages`. If you keep your packages in a
+different directory, you can specify that with this option
+
+### `--parallel`
+
+Runs commands in each package simultaneously. Generally recommended, but you may want to omit this
+if your machine is lower-spec

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kienleholdings/mrt-publish",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Publish packages automatically if their version has changed",
   "main": "./lib/publish.js",
   "types": "./lib/publish.d.ts",
@@ -43,7 +43,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@kienleholdings/mrt-utils": "workspace:^0.1.0",
+    "@kienleholdings/mrt-utils": "workspace:^0.1.1",
     "axios": "^0.25.0",
     "minimist-lite": "^2.1.0",
     "semver": "^7.3.5",

--- a/packages/publish/src/index.ts
+++ b/packages/publish/src/index.ts
@@ -5,7 +5,7 @@ import publish from './publish';
 
 const DEFAULT_ARGS: RunArgs = {
   npmCommand: 'pnpm',
-  packagesDir: './packages',
+  packagesDir: 'packages',
   parallel: false,
 };
 

--- a/packages/run/CHANGELOG.md
+++ b/packages/run/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2022-01-24
+
+### Added
+
+- N / A
+
+### Changed
+
+- Updated `@kienleholdings/mrt-utils` to `0.1.1` in order to fix a bug where the script looked for
+packages in the directory where the script was stored rather than the directory where the script
+was launched from
+- Changed the default module folder from `./packages` to `packages` to allow for better Windows
+path resolution
+
+### Removed
+
+- N / A
+
 ## [0.1.0] - 2022-01-24
 
 ### Added

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kienleholdings/mrt-run",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Run parallel commands in monorepos with no fuss",
   "main": "./lib/run.js",
   "types": "./lib/run.d.ts",
@@ -42,7 +42,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@kienleholdings/mrt-utils": "workspace:^0.1.0",
+    "@kienleholdings/mrt-utils": "workspace:^0.1.1",
     "minimist-lite": "^2.1.0",
     "tslib": "^2.3.1"
   }

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -5,7 +5,7 @@ import run from './run';
 
 const DEFAULT_ARGS: RunArgs = {
   npmCommand: 'pnpm',
-  packagesDir: './packages',
+  packagesDir: 'packages',
   parallel: false,
 };
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2022-01-24
+
+### Added
+
+- Added a function to only scan for folders in the provided packages directory (users were
+reporting bugs where `.DS_STORE` files were showing up as packages)
+
+### Changed
+
+- Replaced `__dirname` with `process.cwd()` to use the directory where the script is executed, not
+the directory where the module is stored
+- Changed directory resolution from `path.join()` to `path.resolve()` for finding packages
+
+### Removed
+
+- N / A
+
 ## [0.1.0] - 2022-01-24
 
 ### Added

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kienleholdings/mrt-utils",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared code for @kienleholdings/monorepo-tools commands",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,6 +1,6 @@
 import execa, { ExecaError } from 'execa';
 import { readdir, readFile } from 'fs/promises';
-import { join } from 'path';
+import { join, resolve } from 'path';
 
 export interface RunArgs {
   npmCommand: string;
@@ -32,11 +32,13 @@ export const logError = (message: string): void => {
 };
 
 export const getPackagesFromDirectory = async (packagesDir: string): Promise<Package[]> => {
-  const resolvedPackagesDir = join(__dirname, packagesDir);
+  const resolvedPackagesDir = resolve(process.cwd(), packagesDir);
 
   let pkgPaths: string[];
   try {
-    pkgPaths = await readdir(resolvedPackagesDir);
+    pkgPaths = (await readdir(resolvedPackagesDir, { withFileTypes: true }))
+      .filter((dirent) => dirent.isDirectory())
+      .map((dirent) => dirent.name);
   } catch (err) {
     throw new Error(
       `There was an error reading the directory ${resolvedPackagesDir}: ${err.message}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
       '@kienleholdings/base-tsconfig': ^0.1.7
       '@kienleholdings/eslint-config-base': ^0.1.8
       '@kienleholdings/markdownlint-config': ^0.1.0
-      '@kienleholdings/mrt-utils': workspace:^0.1.0
+      '@kienleholdings/mrt-utils': workspace:^0.1.1
       '@kienleholdings/prettier-config': ^0.1.3
       '@types/node': ^17.0.10
       '@types/semver': ^7.3.9
@@ -50,7 +50,7 @@ importers:
       '@kienleholdings/base-tsconfig': ^0.1.7
       '@kienleholdings/eslint-config-base': ^0.1.8
       '@kienleholdings/markdownlint-config': ^0.1.0
-      '@kienleholdings/mrt-utils': workspace:^0.1.0
+      '@kienleholdings/mrt-utils': workspace:^0.1.1
       '@kienleholdings/prettier-config': ^0.1.3
       '@types/node': ^17.0.10
       eslint: 7.x


### PR DESCRIPTION
## mrt-publish [0.1.1] - 2022-01-24

### Added

- Added a `README.md`

### Changed

- Updated `@kienleholdings/mrt-utils` to `0.1.1` in order to fix a bug where the script looked for
packages in the directory where the script was stored rather than the directory where the script
was launched from
- Changed the default module folder from `./packages` to `packages` to allow for better Windows
path resolution

### Removed

- N / A

## mrt-run [0.1.1] - 2022-01-24

### Added

- N / A

### Changed

- Updated `@kienleholdings/mrt-utils` to `0.1.1` in order to fix a bug where the script looked for
packages in the directory where the script was stored rather than the directory where the script
was launched from
- Changed the default module folder from `./packages` to `packages` to allow for better Windows
path resolution

### Removed

- N / A

## mrt-utils [0.1.1] - 2022-01-24

### Added

- Added a function to only scan for folders in the provided packages directory (users were
reporting bugs where `.DS_STORE` files were showing up as packages)

### Changed

- Replaced `__dirname` with `process.cwd()` to use the directory where the script is executed, not
the directory where the module is stored
- Changed directory resolution from `path.join()` to `path.resolve()` for finding packages

### Removed

- N / A
