### PR TITLE
Exit process on run task failure

### DIFF
--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -32,6 +32,7 @@ const run = async (args: RunArgs, fullCommand: string): Promise<void> => {
     await executionFunction(packagesWithCommand, npmCommand, ['run', ...command]);
   } catch (err) {
     logError(err.message);
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
Zephyr surfaced a bug where when eslint failed, the CI was still showing as passing. Looking into the mrt code, I noticed that we weren't exiting the process on the `try / catch` when running child processes. This PR fixes that