### PR TITLE
mrt-run 0.1.2

### DIFF
--- a/packages/run/CHANGELOG.md
+++ b/packages/run/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2022-02-17
+
+### Added
+
+- Added `process.exit(1)` to the `try / catch` block that handles executing child processes
+
+### Changed
+
+- N / A
+
+### Removed
+
+- N / A
+
 ## [0.1.1] - 2022-01-24
 
 ### Added

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kienleholdings/mrt-run",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Run parallel commands in monorepos with no fuss",
   "main": "./lib/run.js",
   "types": "./lib/run.d.ts",

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -32,6 +32,7 @@ const run = async (args: RunArgs, fullCommand: string): Promise<void> => {
     await executionFunction(packagesWithCommand, npmCommand, ['run', ...command]);
   } catch (err) {
     logError(err.message);
+    process.exit(1);
   }
 };
 


### PR DESCRIPTION
## mrt-tools [0.1.2] - 2022-02-17

### Added

- Added `process.exit(1)` to the `try / catch` block that handles executing child processes

### Changed

- N / A

### Removed

- N / A