### PR TITLE
Fix Private Registry Publish Bug

### DIFF
--- a/.markdownlint.cjs
+++ b/.markdownlint.cjs
@@ -1,0 +1,2 @@
+const mdConfig = require('@kienleholdings/markdownlint-config');
+module.exports = mdConfig;

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "scripts": {
     "first-time-prebuild": "cd ./packages/utils && pnpm run build && cd ../run && pnpm run build && cd ../..",
     "build": "node ./packages/run/lib/index.js build --parallel",
-    "lint": "node ./packages/run/lib/index.js lint --parallel",
+    "lint": "markdownlint-cli2 \"./*.md\" && node ./packages/run/lib/index.js lint --parallel",
     "test": "node ./packages/run/lib/index.js test --parallel",
     "publish-ci": "node ./packages/publish/lib/index.js"
   },
   "devDependencies": {
-    "@kienleholdings/prettier-config": "^0.1.3",
-    "prettier": "^2.5.1"
+    "@kienleholdings/markdownlint-config": "^0.1.1",
+    "@kienleholdings/prettier-config": "^0.1.4",
+    "markdownlint-cli2": "^0.4.0",
+    "prettier": "^2.6.2"
   }
 }

--- a/packages/publish/.markdownlint.cjs
+++ b/packages/publish/.markdownlint.cjs
@@ -1,0 +1,2 @@
+const mdConfig = require('@kienleholdings/markdownlint-config');
+module.exports = mdConfig;

--- a/packages/publish/CHANGELOG.md
+++ b/packages/publish/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2022-03-3
+
+### Added
+
+- N / A
+
+### Changed
+
+- Updated `@kienleholdings/mrt-utils` to `0.2.0` in order to fix a bug where users that used the
+package to publish packages in private registries couldn't properly check if the package was at the
+latest version or not (wow, that's a lot of "package" in one sentence)
+
+### Removed
+
+- Removed `axios` from package dependencies
+
 ## [0.1.1] - 2022-01-24
 
 ### Added

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -6,19 +6,19 @@
 
 With pnpm (recommended)
 
-```
+```bash
 pnpm install @kienleholdings/mrt-publish
 ```
 
 With yarn
 
-```
+```bash
 yarn add @kienleholdings/mrt-publish
 ```
 
 With npm
 
-```
+```bash
 npm install @kienleholdings/mrt-publish
 ```
 

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kienleholdings/mrt-publish",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Publish packages automatically if their version has changed",
   "main": "./lib/publish.js",
   "types": "./lib/publish.d.ts",
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc --declaration",
-    "lint": "eslint --ext .ts src/",
+    "lint": "markdownlint-cli2 \"./*.md\" && eslint --ext .ts src/",
     "test": "echo \"TODO: Implement Tests\""
   },
   "publishConfig": {
@@ -31,21 +31,20 @@
   },
   "homepage": "https://github.com/kienleholdings/monorepo-tools/tree/main/packages/run#readme",
   "devDependencies": {
-    "@kienleholdings/base-tsconfig": "^0.1.7",
-    "@kienleholdings/eslint-config-base": "^0.1.8",
-    "@kienleholdings/markdownlint-config": "^0.1.0",
-    "@kienleholdings/prettier-config": "^0.1.3",
-    "@types/node": "^17.0.10",
+    "@kienleholdings/base-tsconfig": "^0.1.8",
+    "@kienleholdings/eslint-config-base": "^0.1.9",
+    "@kienleholdings/markdownlint-config": "^0.1.1",
+    "@kienleholdings/prettier-config": "^0.1.4",
+    "@types/node": "16.x",
     "@types/semver": "^7.3.9",
-    "eslint": "7.x",
+    "eslint": "~8.12.0",
     "markdownlint-cli2": "^0.4.0",
-    "prettier": "^2.5.1",
-    "typescript": "^4.5.5"
+    "prettier": "^2.6.2",
+    "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@kienleholdings/mrt-utils": "workspace:^0.1.1",
-    "axios": "^0.25.0",
-    "minimist-lite": "^2.1.0",
+    "@kienleholdings/mrt-utils": "workspace:^0.2.0",
+    "minimist-lite": "^2.2.1",
     "semver": "^7.3.5",
     "tslib": "^2.3.1"
   }

--- a/packages/run/.markdownlint.cjs
+++ b/packages/run/.markdownlint.cjs
@@ -1,0 +1,2 @@
+const mdConfig = require('@kienleholdings/markdownlint-config');
+module.exports = mdConfig;

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -6,19 +6,19 @@
 
 With pnpm (recommended)
 
-```
+```bash
 pnpm install @kienleholdings/mrt-run
 ```
 
 With yarn
 
-```
+```bash
 yarn add @kienleholdings/mrt-run
 ```
 
 With npm
 
-```
+```bash
 npm install @kienleholdings/mrt-run
 ```
 

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc --declaration",
-    "lint": "eslint --ext .ts src/",
+    "lint": "markdownlint-cli2 \"./*.md\" && eslint --ext .ts src/",
     "test": "echo \"TODO: Implement Tests\""
   },
   "publishConfig": {
@@ -31,19 +31,19 @@
   },
   "homepage": "https://github.com/kienleholdings/monorepo-tools/tree/main/packages/run#readme",
   "devDependencies": {
-    "@kienleholdings/base-tsconfig": "^0.1.7",
-    "@kienleholdings/eslint-config-base": "^0.1.8",
-    "@kienleholdings/markdownlint-config": "^0.1.0",
-    "@kienleholdings/prettier-config": "^0.1.3",
-    "@types/node": "^17.0.10",
-    "eslint": "7.x",
+    "@kienleholdings/base-tsconfig": "^0.1.8",
+    "@kienleholdings/eslint-config-base": "^0.1.9",
+    "@kienleholdings/markdownlint-config": "^0.1.1",
+    "@kienleholdings/prettier-config": "^0.1.4",
+    "@types/node": "16.x",
+    "eslint": "~8.12.0",
     "markdownlint-cli2": "^0.4.0",
-    "prettier": "^2.5.1",
-    "typescript": "^4.5.5"
+    "prettier": "^2.6.2",
+    "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@kienleholdings/mrt-utils": "workspace:^0.1.1",
-    "minimist-lite": "^2.1.0",
+    "@kienleholdings/mrt-utils": "workspace:^0.2.0",
+    "minimist-lite": "^2.2.1",
     "tslib": "^2.3.1"
   }
 }

--- a/packages/utils/.markdownlint.cjs
+++ b/packages/utils/.markdownlint.cjs
@@ -1,0 +1,2 @@
+const mdConfig = require('@kienleholdings/markdownlint-config');
+module.exports = mdConfig;

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2022-03-03
+
+### Added
+
+- Added a function to execute a single command and capture the output as a string
+
+### Changed
+
+- N / A
+
+### Removed
+
+- N / A
+
 ## [0.1.1] - 2022-01-24
 
 ### Added

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -6,19 +6,19 @@
 
 With pnpm (recommended)
 
-```
+```bash
 pnpm install @kienleholdings/mrt-utils
 ```
 
 With yarn
 
-```
+```bash
 yarn add @kienleholdings/mrt-utils
 ```
 
 With npm
 
-```
+```bash
 npm install @kienleholdings/mrt-utils
 ```
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@kienleholdings/mrt-utils",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shared code for @kienleholdings/monorepo-tools commands",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "prettier": "@kienleholdings/prettier-config",
   "scripts": {
     "build": "tsc --declaration",
+    "lint": "markdownlint-cli2 \"./*.md\" && eslint --ext .ts src/",
     "test": "echo \"TODO: Implement Tests\""
   },
   "publishConfig": {
@@ -27,19 +28,19 @@
   },
   "homepage": "https://github.com/kienleholdings/monorepo-tools/tree/main/packages/run#readme",
   "devDependencies": {
-    "@kienleholdings/base-tsconfig": "^0.1.7",
-    "@kienleholdings/eslint-config-base": "^0.1.8",
-    "@kienleholdings/markdownlint-config": "^0.1.0",
-    "@kienleholdings/prettier-config": "^0.1.3",
-    "@types/node": "^17.0.10",
-    "eslint": "7.x",
+    "@kienleholdings/base-tsconfig": "^0.1.8",
+    "@kienleholdings/eslint-config-base": "^0.1.9",
+    "@kienleholdings/markdownlint-config": "^0.1.1",
+    "@kienleholdings/prettier-config": "^0.1.4",
+    "@types/node": "16.x",
+    "eslint": "~8.12.0",
     "markdownlint-cli2": "^0.4.0",
-    "prettier": "^2.5.1",
-    "typescript": "^4.5.5"
+    "prettier": "^2.6.2",
+    "typescript": "^4.6.3"
   },
   "dependencies": {
     "execa": "^5.1.1",
-    "minimist-lite": "^2.1.0",
+    "minimist-lite": "^2.2.1",
     "tslib": "^2.3.1"
   }
 }

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -81,6 +81,33 @@ export const handleExecaError = (err: ExecaError, packageName: string): void => 
   throw err;
 };
 
+// In order to structure variable output in a predictable way, this is never run parallel
+export const executeCommandWithLocalOutput = async (
+  command: string,
+  args: string[]
+): Promise<string> => {
+  let output = '';
+  const commandPromise = execa(command, args);
+
+  // eslint-disable-next-line no-loop-func
+  commandPromise.stdout?.on('data', (log) => {
+    output += log;
+  });
+  // eslint-disable-next-line no-loop-func
+  commandPromise.stderr?.on('data', (log) => {
+    output += log;
+  });
+
+  try {
+    // We're intentionally removing parallel processing, therefor I'm disabling this rule
+    // eslint-disable-next-line no-await-in-loop
+    await commandPromise;
+  } catch (err) {
+    output = err.message;
+  }
+  return output;
+};
+
 export const executeCommandsParallel = async (
   packages: Package[],
   command: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,146 +4,128 @@ importers:
 
   .:
     specifiers:
-      '@kienleholdings/prettier-config': ^0.1.3
-      prettier: ^2.5.1
+      '@kienleholdings/markdownlint-config': ^0.1.1
+      '@kienleholdings/prettier-config': ^0.1.4
+      markdownlint-cli2: ^0.4.0
+      prettier: ^2.6.2
     devDependencies:
-      '@kienleholdings/prettier-config': 0.1.3_prettier@2.5.1
-      prettier: 2.5.1
+      '@kienleholdings/markdownlint-config': 0.1.1_markdownlint-cli2@0.4.0
+      '@kienleholdings/prettier-config': 0.1.4_prettier@2.6.2
+      markdownlint-cli2: 0.4.0
+      prettier: 2.6.2
 
   packages/publish:
     specifiers:
-      '@kienleholdings/base-tsconfig': ^0.1.7
-      '@kienleholdings/eslint-config-base': ^0.1.8
-      '@kienleholdings/markdownlint-config': ^0.1.0
-      '@kienleholdings/mrt-utils': workspace:^0.1.1
-      '@kienleholdings/prettier-config': ^0.1.3
-      '@types/node': ^17.0.10
+      '@kienleholdings/base-tsconfig': ^0.1.8
+      '@kienleholdings/eslint-config-base': ^0.1.9
+      '@kienleholdings/markdownlint-config': ^0.1.1
+      '@kienleholdings/mrt-utils': workspace:^0.1.2
+      '@kienleholdings/prettier-config': ^0.1.4
+      '@types/node': 16.x
       '@types/semver': ^7.3.9
-      axios: ^0.25.0
-      eslint: 7.x
+      eslint: ~8.12.0
       markdownlint-cli2: ^0.4.0
-      minimist-lite: ^2.1.0
-      prettier: ^2.5.1
+      minimist-lite: ^2.2.1
+      prettier: ^2.6.2
       semver: ^7.3.5
       tslib: ^2.3.1
-      typescript: ^4.5.5
+      typescript: ^4.6.3
     dependencies:
       '@kienleholdings/mrt-utils': link:../utils
-      axios: 0.25.0
-      minimist-lite: 2.1.0
+      minimist-lite: 2.2.1
       semver: 7.3.5
       tslib: 2.3.1
     devDependencies:
-      '@kienleholdings/base-tsconfig': 0.1.7_typescript@4.5.5
-      '@kienleholdings/eslint-config-base': 0.1.8_a136e7a0cc991e454d4248263e7a08e1
-      '@kienleholdings/markdownlint-config': 0.1.0_markdownlint-cli2@0.4.0
-      '@kienleholdings/prettier-config': 0.1.3_prettier@2.5.1
-      '@types/node': 17.0.10
+      '@kienleholdings/base-tsconfig': 0.1.8_typescript@4.6.3
+      '@kienleholdings/eslint-config-base': 0.1.9_5e299a0150de90114025944ffbd56d65
+      '@kienleholdings/markdownlint-config': 0.1.1_markdownlint-cli2@0.4.0
+      '@kienleholdings/prettier-config': 0.1.4_prettier@2.6.2
+      '@types/node': 16.11.26
       '@types/semver': 7.3.9
-      eslint: 7.32.0
+      eslint: 8.12.0
       markdownlint-cli2: 0.4.0
-      prettier: 2.5.1
-      typescript: 4.5.5
+      prettier: 2.6.2
+      typescript: 4.6.3
 
   packages/run:
     specifiers:
-      '@kienleholdings/base-tsconfig': ^0.1.7
-      '@kienleholdings/eslint-config-base': ^0.1.8
-      '@kienleholdings/markdownlint-config': ^0.1.0
+      '@kienleholdings/base-tsconfig': ^0.1.8
+      '@kienleholdings/eslint-config-base': ^0.1.9
+      '@kienleholdings/markdownlint-config': ^0.1.1
       '@kienleholdings/mrt-utils': workspace:^0.1.1
-      '@kienleholdings/prettier-config': ^0.1.3
-      '@types/node': ^17.0.10
-      eslint: 7.x
+      '@kienleholdings/prettier-config': ^0.1.4
+      '@types/node': 16.x
+      eslint: ~8.12.0
       markdownlint-cli2: ^0.4.0
-      minimist-lite: ^2.1.0
-      prettier: ^2.5.1
+      minimist-lite: ^2.2.1
+      prettier: ^2.6.2
       tslib: ^2.3.1
-      typescript: ^4.5.5
+      typescript: ^4.6.3
     dependencies:
       '@kienleholdings/mrt-utils': link:../utils
-      minimist-lite: 2.1.0
+      minimist-lite: 2.2.1
       tslib: 2.3.1
     devDependencies:
-      '@kienleholdings/base-tsconfig': 0.1.7_typescript@4.5.5
-      '@kienleholdings/eslint-config-base': 0.1.8_a136e7a0cc991e454d4248263e7a08e1
-      '@kienleholdings/markdownlint-config': 0.1.0_markdownlint-cli2@0.4.0
-      '@kienleholdings/prettier-config': 0.1.3_prettier@2.5.1
-      '@types/node': 17.0.10
-      eslint: 7.32.0
+      '@kienleholdings/base-tsconfig': 0.1.8_typescript@4.6.3
+      '@kienleholdings/eslint-config-base': 0.1.9_5e299a0150de90114025944ffbd56d65
+      '@kienleholdings/markdownlint-config': 0.1.1_markdownlint-cli2@0.4.0
+      '@kienleholdings/prettier-config': 0.1.4_prettier@2.6.2
+      '@types/node': 16.11.26
+      eslint: 8.12.0
       markdownlint-cli2: 0.4.0
-      prettier: 2.5.1
-      typescript: 4.5.5
+      prettier: 2.6.2
+      typescript: 4.6.3
 
   packages/utils:
     specifiers:
-      '@kienleholdings/base-tsconfig': ^0.1.7
-      '@kienleholdings/eslint-config-base': ^0.1.8
-      '@kienleholdings/markdownlint-config': ^0.1.0
-      '@kienleholdings/prettier-config': ^0.1.3
-      '@types/node': ^17.0.10
-      eslint: 7.x
+      '@kienleholdings/base-tsconfig': ^0.1.8
+      '@kienleholdings/eslint-config-base': ^0.1.9
+      '@kienleholdings/markdownlint-config': ^0.1.1
+      '@kienleholdings/prettier-config': ^0.1.4
+      '@types/node': 16.x
+      eslint: ~8.12.0
       execa: ^5.1.1
       markdownlint-cli2: ^0.4.0
-      minimist-lite: ^2.1.0
-      prettier: ^2.5.1
+      minimist-lite: ^2.2.1
+      prettier: ^2.6.2
       tslib: ^2.3.1
-      typescript: ^4.5.5
+      typescript: ^4.6.3
     dependencies:
       execa: 5.1.1
-      minimist-lite: 2.1.0
+      minimist-lite: 2.2.1
       tslib: 2.3.1
     devDependencies:
-      '@kienleholdings/base-tsconfig': 0.1.7_typescript@4.5.5
-      '@kienleholdings/eslint-config-base': 0.1.8_a136e7a0cc991e454d4248263e7a08e1
-      '@kienleholdings/markdownlint-config': 0.1.0_markdownlint-cli2@0.4.0
-      '@kienleholdings/prettier-config': 0.1.3_prettier@2.5.1
-      '@types/node': 17.0.10
-      eslint: 7.32.0
+      '@kienleholdings/base-tsconfig': 0.1.8_typescript@4.6.3
+      '@kienleholdings/eslint-config-base': 0.1.9_5e299a0150de90114025944ffbd56d65
+      '@kienleholdings/markdownlint-config': 0.1.1_markdownlint-cli2@0.4.0
+      '@kienleholdings/prettier-config': 0.1.4_prettier@2.6.2
+      '@types/node': 16.11.26
+      eslint: 8.12.0
       markdownlint-cli2: 0.4.0
-      prettier: 2.5.1
-      typescript: 4.5.5
+      prettier: 2.6.2
+      typescript: 4.6.3
 
 packages:
 
-  /@babel/code-frame/7.12.11:
-    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
-    dependencies:
-      '@babel/highlight': 7.16.10
-    dev: true
-
-  /@babel/helper-validator-identifier/7.16.7:
-    resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
-  /@babel/highlight/7.16.10:
-    resolution: {integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: true
-
-  /@eslint/eslintrc/0.4.3:
-    resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@eslint/eslintrc/1.2.1:
+    resolution: {integrity: sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.3
-      espree: 7.3.1
+      espree: 9.3.1
       globals: 13.12.0
-      ignore: 4.0.6
+      ignore: 5.2.0
       import-fresh: 3.3.0
-      js-yaml: 3.14.1
+      js-yaml: 4.1.0
       minimatch: 3.0.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@humanwhocodes/config-array/0.5.0:
-    resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
+  /@humanwhocodes/config-array/0.9.5:
+    resolution: {integrity: sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -157,50 +139,50 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@kienleholdings/base-tsconfig/0.1.7_typescript@4.5.5:
-    resolution: {integrity: sha512-FgN6dyz4BPxVUz3FydFXCWp+ZaG74sGLtxQV1uu5XT/xFrlO5jfz6sDj16xOxS+oa3c5kEgR9lmSWvDAGQvurw==}
+  /@kienleholdings/base-tsconfig/0.1.8_typescript@4.6.3:
+    resolution: {integrity: sha512-Yg7f4VFeXkWqmGDsy/u9rHoZBvsDFKMBo032qqCR64h3eA4a7JtOK+KOV5vtgIBayv73JOpiMy4+rH75hUDy8w==}
     peerDependencies:
-      typescript: ^4.3.5
+      typescript: ^4.5.5
     dependencies:
-      typescript: 4.5.5
+      typescript: 4.6.3
     dev: true
 
-  /@kienleholdings/eslint-config-base/0.1.8_a136e7a0cc991e454d4248263e7a08e1:
-    resolution: {integrity: sha512-7IRAqQwhO5gg7mBcOil3Z+YIdSAVwTf+QtIqxsDX3ac6/AOyuUq+VhUF2SrjqLkTxu7/e7RpMicS+IsuHnDHtw==}
+  /@kienleholdings/eslint-config-base/0.1.9_5e299a0150de90114025944ffbd56d65:
+    resolution: {integrity: sha512-WuphVuIQ4Z/zerYDurnguM8so/cxsIZPgYAxOuVGyjRQOE/p7Iz6mSgAjjiOruam6mgDjOegfEFOPFSCQ+Q/JQ==}
     peerDependencies:
-      '@kienleholdings/prettier-config': 0.x
-      eslint: ^7.32.0
-      prettier: ^2.3.2
-      typescript: ^4.3.5
+      '@kienleholdings/prettier-config': ^0.1.4
+      eslint: ^8.7.0
+      prettier: ^2.5.1
+      typescript: ^4.5.5
     dependencies:
-      '@kienleholdings/prettier-config': 0.1.3_prettier@2.5.1
-      '@typescript-eslint/eslint-plugin': 4.33.0_959502c0ea240e86d4d2ba8b8c0fee45
-      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.5.5
-      eslint: 7.32.0
-      eslint-config-airbnb-base: 14.2.1_157002f9dff1b62f2b20650d7e8bf1eb
-      eslint-config-prettier: 8.3.0_eslint@7.32.0
-      eslint-plugin-import: 2.25.4_eslint@7.32.0
-      eslint-plugin-prettier: 3.4.1_6e6a25a49a944db0fa38418c3ba4bc86
-      prettier: 2.5.1
-      typescript: 4.5.5
+      '@kienleholdings/prettier-config': 0.1.4_prettier@2.6.2
+      '@typescript-eslint/eslint-plugin': 5.17.0_689ff565753ecf7c3328c07fad067df5
+      '@typescript-eslint/parser': 5.17.0_eslint@8.12.0+typescript@4.6.3
+      eslint: 8.12.0
+      eslint-config-airbnb-base: 15.0.0_dae71b730d6620b67a20047a747b2eda
+      eslint-config-prettier: 8.3.0_eslint@8.12.0
+      eslint-plugin-import: 2.25.4_eslint@8.12.0
+      eslint-plugin-prettier: 4.0.0_239c1b4ec2edc3ff0d30e1496c93d905
+      prettier: 2.6.2
+      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@kienleholdings/markdownlint-config/0.1.0_markdownlint-cli2@0.4.0:
-    resolution: {integrity: sha512-OGTRmMvSREfDlKE8ZUHXNX2PYAFJgvO8rfyy6qioy4jjtTOOqTgGXoR5h/2YEeWcjvpnTGhwvwnTZrCfBRuhyA==}
+  /@kienleholdings/markdownlint-config/0.1.1_markdownlint-cli2@0.4.0:
+    resolution: {integrity: sha512-hH8srqkl6vyVRWD7MnUWxplKAZChU/T3752Cuaue+O26KKrmRZHHkuEKuqw7aj+qyeyAr9GNJo8pQOBy/l+ymw==}
     peerDependencies:
-      markdownlint-cli2: ^0.2.0
+      markdownlint-cli2: ^0.4.0
     dependencies:
       markdownlint-cli2: 0.4.0
     dev: true
 
-  /@kienleholdings/prettier-config/0.1.3_prettier@2.5.1:
-    resolution: {integrity: sha512-usRqfwFAXpgsHxsSThh/YYTRg98MqBMIthq5U+zKLytPFXKGlZKr5Ikhm2Ahl5FM72PYbZygmcAUmb1dW9/pDA==}
+  /@kienleholdings/prettier-config/0.1.4_prettier@2.6.2:
+    resolution: {integrity: sha512-ase5XaONyTIsJZvwg2fLc8XWpP4pqIYYo2L+x/FeR668C6Z6dF+kGZWbtdSYNI6zuNctgqWMrkDLqZYU5QUUmA==}
     peerDependencies:
-      prettier: ^2.3.2
+      prettier: ^2.5.1
     dependencies:
-      prettier: 2.5.1
+      prettier: 2.6.2
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -232,130 +214,150 @@ packages:
     resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
     dev: true
 
-  /@types/node/17.0.10:
-    resolution: {integrity: sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==}
+  /@types/node/16.11.26:
+    resolution: {integrity: sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==}
     dev: true
 
   /@types/semver/7.3.9:
     resolution: {integrity: sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.33.0_959502c0ea240e86d4d2ba8b8c0fee45:
-    resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/eslint-plugin/5.17.0_689ff565753ecf7c3328c07fad067df5:
+    resolution: {integrity: sha512-qVstvQilEd89HJk3qcbKt/zZrfBZ+9h2ynpAGlWjWiizA7m/MtLT9RoX6gjtpE500vfIg8jogAkDzdCxbsFASQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0+typescript@4.5.5
-      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.5.5
-      '@typescript-eslint/scope-manager': 4.33.0
+      '@typescript-eslint/parser': 5.17.0_eslint@8.12.0+typescript@4.6.3
+      '@typescript-eslint/scope-manager': 5.17.0
+      '@typescript-eslint/type-utils': 5.17.0_eslint@8.12.0+typescript@4.6.3
+      '@typescript-eslint/utils': 5.17.0_eslint@8.12.0+typescript@4.6.3
       debug: 4.3.3
-      eslint: 7.32.0
+      eslint: 8.12.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
+      tsutils: 3.21.0_typescript@4.6.3
+      typescript: 4.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.33.0_eslint@7.32.0+typescript@4.5.5:
-    resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/parser/5.17.0_eslint@8.12.0+typescript@4.6.3:
+    resolution: {integrity: sha512-aRzW9Jg5Rlj2t2/crzhA2f23SIYFlF9mchGudyP0uiD6SenIxzKoLjwzHbafgHn39dNV/TV7xwQkLfFTZlJ4ig==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.17.0
+      '@typescript-eslint/types': 5.17.0
+      '@typescript-eslint/typescript-estree': 5.17.0_typescript@4.6.3
+      debug: 4.3.3
+      eslint: 8.12.0
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager/5.17.0:
+    resolution: {integrity: sha512-062iCYQF/doQ9T2WWfJohQKKN1zmmXVfAcS3xaiialiw8ZUGy05Em6QVNYJGO34/sU1a7a+90U3dUNfqUDHr3w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.17.0
+      '@typescript-eslint/visitor-keys': 5.17.0
+    dev: true
+
+  /@typescript-eslint/type-utils/5.17.0_eslint@8.12.0+typescript@4.6.3:
+    resolution: {integrity: sha512-3hU0RynUIlEuqMJA7dragb0/75gZmwNwFf/QJokWzPehTZousP/MNifVSgjxNcDCkM5HI2K22TjQWUmmHUINSg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': 5.17.0_eslint@8.12.0+typescript@4.6.3
+      debug: 4.3.3
+      eslint: 8.12.0
+      tsutils: 3.21.0_typescript@4.6.3
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/types/5.17.0:
+    resolution: {integrity: sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.17.0_typescript@4.6.3:
+    resolution: {integrity: sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.17.0
+      '@typescript-eslint/visitor-keys': 5.17.0
+      debug: 4.3.3
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.6.3
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.17.0_eslint@8.12.0+typescript@4.6.3:
+    resolution: {integrity: sha512-DVvndq1QoxQH+hFv+MUQHrrWZ7gQ5KcJzyjhzcqB1Y2Xes1UQQkTRPUfRpqhS8mhTWsSb2+iyvDW1Lef5DD7vA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 4.33.0
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.5
-      eslint: 7.32.0
+      '@typescript-eslint/scope-manager': 5.17.0
+      '@typescript-eslint/types': 5.17.0
+      '@typescript-eslint/typescript-estree': 5.17.0_typescript@4.6.3
+      eslint: 8.12.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@7.32.0
+      eslint-utils: 3.0.0_eslint@8.12.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_eslint@7.32.0+typescript@4.5.5:
-    resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  /@typescript-eslint/visitor-keys/5.17.0:
+    resolution: {integrity: sha512-6K/zlc4OfCagUu7Am/BD5k8PSWQOgh34Nrv9Rxe2tBzlJ7uOeJ/h7ugCGDCeEZHT6k2CJBhbk9IsbkPI0uvUkA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/scope-manager': 4.33.0
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.5
-      debug: 4.3.3
-      eslint: 7.32.0
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
+      '@typescript-eslint/types': 5.17.0
+      eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@typescript-eslint/scope-manager/4.33.0:
-    resolution: {integrity: sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dependencies:
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/visitor-keys': 4.33.0
-    dev: true
-
-  /@typescript-eslint/types/4.33.0:
-    resolution: {integrity: sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dev: true
-
-  /@typescript-eslint/typescript-estree/4.33.0_typescript@4.5.5:
-    resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/visitor-keys': 4.33.0
-      debug: 4.3.3
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/visitor-keys/4.33.0:
-    resolution: {integrity: sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    dependencies:
-      '@typescript-eslint/types': 4.33.0
-      eslint-visitor-keys: 2.1.0
-    dev: true
-
-  /acorn-jsx/5.3.2_acorn@7.4.1:
+  /acorn-jsx/5.3.2_acorn@8.7.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 7.4.1
+      acorn: 8.7.0
     dev: true
 
-  /acorn/7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+  /acorn/8.7.0:
+    resolution: {integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -369,30 +371,9 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /ajv/8.9.0:
-    resolution: {integrity: sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==}
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-      uri-js: 4.4.1
-    dev: true
-
-  /ansi-colors/4.1.1:
-    resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
-    engines: {node: '>=6'}
-    dev: true
-
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: true
-
-  /ansi-styles/3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
-    dependencies:
-      color-convert: 1.9.3
     dev: true
 
   /ansi-styles/4.3.0:
@@ -400,12 +381,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
-
-  /argparse/1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-    dependencies:
-      sprintf-js: 1.0.3
     dev: true
 
   /argparse/2.0.1:
@@ -442,19 +417,6 @@ packages:
       es-abstract: 1.19.1
     dev: true
 
-  /astral-regex/2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /axios/0.25.0:
-    resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
-    dependencies:
-      follow-redirects: 1.14.7
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -485,15 +447,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /chalk/2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-    dev: true
-
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -502,21 +455,11 @@ packages:
       supports-color: 7.2.0
     dev: true
 
-  /color-convert/1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-    dependencies:
-      color-name: 1.1.3
-    dev: true
-
   /color-convert/2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
-
-  /color-name/1.1.3:
-    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
     dev: true
 
   /color-name/1.1.4:
@@ -595,17 +538,6 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /emoji-regex/8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
-
-  /enquirer/2.3.6:
-    resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
-    engines: {node: '>=8.6'}
-    dependencies:
-      ansi-colors: 4.1.1
-    dev: true
-
   /entities/2.1.0:
     resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}
     dev: true
@@ -645,37 +577,33 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /escape-string-regexp/1.0.5:
-    resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
-    engines: {node: '>=0.8.0'}
-    dev: true
-
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-airbnb-base/14.2.1_157002f9dff1b62f2b20650d7e8bf1eb:
-    resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
-    engines: {node: '>= 6'}
+  /eslint-config-airbnb-base/15.0.0_dae71b730d6620b67a20047a747b2eda:
+    resolution: {integrity: sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==}
+    engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
-      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-      eslint-plugin-import: ^2.22.1
+      eslint: ^7.32.0 || ^8.2.0
+      eslint-plugin-import: ^2.25.2
     dependencies:
       confusing-browser-globals: 1.0.11
-      eslint: 7.32.0
-      eslint-plugin-import: 2.25.4_eslint@7.32.0
+      eslint: 8.12.0
+      eslint-plugin-import: 2.25.4_eslint@8.12.0
       object.assign: 4.1.2
       object.entries: 1.1.5
+      semver: 6.3.0
     dev: true
 
-  /eslint-config-prettier/8.3.0_eslint@7.32.0:
+  /eslint-config-prettier/8.3.0_eslint@8.12.0:
     resolution: {integrity: sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 7.32.0
+      eslint: 8.12.0
     dev: true
 
   /eslint-import-resolver-node/0.3.6:
@@ -693,7 +621,7 @@ packages:
       find-up: 2.1.0
     dev: true
 
-  /eslint-plugin-import/2.25.4_eslint@7.32.0:
+  /eslint-plugin-import/2.25.4_eslint@8.12.0:
     resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -703,7 +631,7 @@ packages:
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 7.32.0
+      eslint: 8.12.0
       eslint-import-resolver-node: 0.3.6
       eslint-module-utils: 2.7.2
       has: 1.0.3
@@ -715,20 +643,20 @@ packages:
       tsconfig-paths: 3.12.0
     dev: true
 
-  /eslint-plugin-prettier/3.4.1_6e6a25a49a944db0fa38418c3ba4bc86:
-    resolution: {integrity: sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==}
+  /eslint-plugin-prettier/4.0.0_239c1b4ec2edc3ff0d30e1496c93d905:
+    resolution: {integrity: sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
-      eslint: '>=5.0.0'
+      eslint: '>=7.28.0'
       eslint-config-prettier: '*'
-      prettier: '>=1.13.0'
+      prettier: '>=2.0.0'
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
     dependencies:
-      eslint: 7.32.0
-      eslint-config-prettier: 8.3.0_eslint@7.32.0
-      prettier: 2.5.1
+      eslint: 8.12.0
+      eslint-config-prettier: 8.3.0_eslint@8.12.0
+      prettier: 2.6.2
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -740,26 +668,22 @@ packages:
       estraverse: 4.3.0
     dev: true
 
-  /eslint-utils/2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
-    engines: {node: '>=6'}
+  /eslint-scope/7.1.1:
+    resolution: {integrity: sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      eslint-visitor-keys: 1.3.0
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@7.32.0:
+  /eslint-utils/3.0.0_eslint@8.12.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 7.32.0
+      eslint: 8.12.0
       eslint-visitor-keys: 2.1.0
-    dev: true
-
-  /eslint-visitor-keys/1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
     dev: true
 
   /eslint-visitor-keys/2.1.0:
@@ -767,68 +691,62 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint/7.32.0:
-    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /eslint-visitor-keys/3.3.0:
+    resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /eslint/8.12.0:
+    resolution: {integrity: sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.3
-      '@humanwhocodes/config-array': 0.5.0
+      '@eslint/eslintrc': 1.2.1
+      '@humanwhocodes/config-array': 0.9.5
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
       debug: 4.3.3
       doctrine: 3.0.0
-      enquirer: 2.3.6
       escape-string-regexp: 4.0.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-      eslint-visitor-keys: 2.1.0
-      espree: 7.3.1
+      eslint-scope: 7.1.1
+      eslint-utils: 3.0.0_eslint@8.12.0
+      eslint-visitor-keys: 3.3.0
+      espree: 9.3.1
       esquery: 1.4.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.2
+      glob-parent: 6.0.2
       globals: 13.12.0
-      ignore: 4.0.6
+      ignore: 5.2.0
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 3.14.1
+      js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
       minimatch: 3.0.4
       natural-compare: 1.4.0
       optionator: 0.9.1
-      progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.3.5
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
-      table: 6.8.0
       text-table: 0.2.0
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /espree/7.3.1:
-    resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /espree/9.3.1:
+    resolution: {integrity: sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 7.4.1
-      acorn-jsx: 5.3.2_acorn@7.4.1
-      eslint-visitor-keys: 1.3.0
-    dev: true
-
-  /esprima/4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
+      acorn: 8.7.0
+      acorn-jsx: 5.3.2_acorn@8.7.0
+      eslint-visitor-keys: 3.3.0
     dev: true
 
   /esquery/1.4.0:
@@ -941,16 +859,6 @@ packages:
     resolution: {integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==}
     dev: true
 
-  /follow-redirects/1.14.7:
-    resolution: {integrity: sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
-
   /fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
     dev: true
@@ -987,6 +895,13 @@ packages:
   /glob-parent/5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
+  /glob-parent/6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
     dev: true
@@ -1037,11 +952,6 @@ packages:
     resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==}
     dev: true
 
-  /has-flag/3.0.0:
-    resolution: {integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=}
-    engines: {node: '>=4'}
-    dev: true
-
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1070,11 +980,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
     dev: false
-
-  /ignore/4.0.6:
-    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
-    engines: {node: '>= 4'}
-    dev: true
 
   /ignore/5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
@@ -1151,11 +1056,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /is-fullwidth-code-point/3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
-    dev: true
-
   /is-glob/4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -1220,24 +1120,15 @@ packages:
   /isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
 
-  /js-tokens/4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
-
-  /js-yaml/3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+  /js-yaml/4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
     dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
+      argparse: 2.0.1
     dev: true
 
   /json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    dev: true
-
-  /json-schema-traverse/1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
     dev: true
 
   /json-stable-stringify-without-jsonify/1.0.1:
@@ -1275,10 +1166,6 @@ packages:
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: true
-
-  /lodash.truncate/4.4.2:
-    resolution: {integrity: sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=}
     dev: true
 
   /lru-cache/6.0.0:
@@ -1363,8 +1250,8 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /minimist-lite/2.1.0:
-    resolution: {integrity: sha512-7OMzeqL1AS8PygHh3f5OZs6DfnzNcJUKWgMctSxqJH8vaWmiZDLyG6UEx8xIgo+06F170hxr3OGb0XSK4D/fzQ==}
+  /minimist-lite/2.2.1:
+    resolution: {integrity: sha512-RSrWIRWGYoM2TDe102s7aIyeSipXMIXKb1fSHYx1tAbxAV0z4g2xR6ra3oPzkTqFb0EIUz1H3A/qvYYeDd+/qQ==}
     dev: false
 
   /minimist/1.2.5:
@@ -1522,15 +1409,10 @@ packages:
       fast-diff: 1.2.0
     dev: true
 
-  /prettier/2.5.1:
-    resolution: {integrity: sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==}
+  /prettier/2.6.2:
+    resolution: {integrity: sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: true
-
-  /progress/2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
     dev: true
 
   /punycode/2.1.1:
@@ -1545,11 +1427,6 @@ packages:
   /regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
-    dev: true
-
-  /require-from-string/2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /resolve-from/4.0.0:
@@ -1582,6 +1459,11 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: true
+
+  /semver/6.3.0:
+    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    hasBin: true
     dev: true
 
   /semver/7.3.5:
@@ -1621,28 +1503,6 @@ packages:
   /slash/4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
-    dev: true
-
-  /slice-ansi/4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
-    dev: true
-
-  /sprintf-js/1.0.3:
-    resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
-    dev: true
-
-  /string-width/4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
     dev: true
 
   /string.prototype.trimend/1.0.4:
@@ -1686,13 +1546,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
-  /supports-color/5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
-    dependencies:
-      has-flag: 3.0.0
-    dev: true
-
   /supports-color/7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1703,17 +1556,6 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
-
-  /table/6.8.0:
-    resolution: {integrity: sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==}
-    engines: {node: '>=10.0.0'}
-    dependencies:
-      ajv: 8.9.0
-      lodash.truncate: 4.4.2
-      slice-ansi: 4.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
     dev: true
 
   /text-table/0.2.0:
@@ -1744,14 +1586,14 @@ packages:
     resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
     dev: false
 
-  /tsutils/3.21.0_typescript@4.5.5:
+  /tsutils/3.21.0_typescript@4.6.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.5.5
+      typescript: 4.6.3
     dev: true
 
   /type-check/0.4.0:
@@ -1766,8 +1608,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /typescript/4.5.5:
-    resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
+  /typescript/4.6.3:
+    resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
       '@kienleholdings/base-tsconfig': ^0.1.8
       '@kienleholdings/eslint-config-base': ^0.1.9
       '@kienleholdings/markdownlint-config': ^0.1.1
-      '@kienleholdings/mrt-utils': workspace:^0.1.2
+      '@kienleholdings/mrt-utils': workspace:^0.2.0
       '@kienleholdings/prettier-config': ^0.1.4
       '@types/node': 16.x
       '@types/semver': ^7.3.9
@@ -52,7 +52,7 @@ importers:
       '@kienleholdings/base-tsconfig': ^0.1.8
       '@kienleholdings/eslint-config-base': ^0.1.9
       '@kienleholdings/markdownlint-config': ^0.1.1
-      '@kienleholdings/mrt-utils': workspace:^0.1.1
+      '@kienleholdings/mrt-utils': workspace:^0.2.0
       '@kienleholdings/prettier-config': ^0.1.4
       '@types/node': 16.x
       eslint: ~8.12.0


### PR DESCRIPTION
This PR fixes a bug where users that used private npm registries (such as GitHub packages or NPM Pro / Team) couldn't detect what the latest version of their package was and 0.0.0 was returned every time